### PR TITLE
Fix query selector to find chat send button

### DIFF
--- a/src/ui/components/UserDiceRollItemForm.jsx
+++ b/src/ui/components/UserDiceRollItemForm.jsx
@@ -59,7 +59,7 @@ const UserDiceRollItemForm = (props) => {
 
     const onBtnRollClick = (event) => {
         const textAreas = document.getElementsByTagName("textarea");
-        const btns = document.querySelectorAll("button[disabled]:has(> i)");
+        const btns = document.querySelectorAll("button[disabled]:has(i)");
         if (textAreas && textAreas[0] && btns && btns[0]) {
             var chatTextInput = textAreas[0];
             chatTextInput.value = `roll ${props.setName}.${label}`;


### PR DESCRIPTION
Google must have changed the button since the last fix to the query selector.

Fixes #14 and fixes #15